### PR TITLE
Clean up __init__

### DIFF
--- a/h5py-stubs/__init__.pyi
+++ b/h5py-stubs/__init__.pyi
@@ -2,7 +2,7 @@ import atexit
 from types import ModuleType
 from typing import Final
 
-from . import h5a, h5d, h5ds, h5f, h5fd, h5g, h5p, h5pl, h5py_warnings, h5r, h5s, h5t, h5z, utils, version
+from . import h5, h5a, h5d, h5ds, h5f, h5fd, h5g, h5p, h5pl, h5py_warnings, h5r, h5s, h5t, h5z, utils, version
 from ._hl import filters
 from ._hl.attrs import AttributeManager
 from ._hl.base import Empty, HLObject, is_hdf5

--- a/h5py-stubs/__init__.pyi
+++ b/h5py-stubs/__init__.pyi
@@ -1,19 +1,21 @@
 import atexit
 from warnings import warn as _warn
+
 from . import _errors, h5a, h5d, h5ds, h5f, h5fd, h5g, h5p, h5pl, h5r, h5s, h5t, h5z, version
-from ._conv import register_converters as _register_converters, unregister_converters as _unregister_converters
-from .h5z import _register_lzf
+from ._conv import register_converters as _register_converters
+from ._conv import unregister_converters as _unregister_converters
 from ._hl import filters
+from ._hl.attrs import AttributeManager
 from ._hl.base import Empty, HLObject, is_hdf5
-from ._hl.files import File, register_driver, registered_drivers, unregister_driver
-from ._hl.group import ExternalLink, Group, HardLink, SoftLink
 from ._hl.dataset import Dataset
 from ._hl.datatype import Datatype
-from ._hl.attrs import AttributeManager
+from ._hl.files import File, register_driver, registered_drivers, unregister_driver
+from ._hl.group import ExternalLink, Group, HardLink, SoftLink
 from ._hl.vds import VirtualLayout, VirtualSource
 from ._selector import MultiBlockSlice
 from .h5 import get_config
 from .h5r import Reference, RegionReference
+from .h5s import UNLIMITED
 from .h5t import (
     check_dtype,
     check_enum_dtype,
@@ -29,13 +31,11 @@ from .h5t import (
     string_dtype,
     vlen_dtype,
 )
-from .h5s import UNLIMITED
+from .h5z import _register_lzf
 from .version import version as __version__
 
-def run_tests(args=...):  # -> int:
-    ...
-def enable_ipython_completer():  # -> None:
-    ...
+def run_tests(args: str = ...) -> int: ...
+def enable_ipython_completer() -> None: ...
 
 __all__ = [
     "AttributeManager",

--- a/h5py-stubs/__init__.pyi
+++ b/h5py-stubs/__init__.pyi
@@ -1,11 +1,8 @@
 import atexit
 from types import ModuleType
 from typing import Final
-from warnings import warn as _warn
 
-from . import _errors, h5a, h5d, h5ds, h5f, h5fd, h5g, h5p, h5pl, h5py_warnings, h5r, h5s, h5t, h5z, utils, version
-from ._conv import register_converters as _register_converters
-from ._conv import unregister_converters as _unregister_converters
+from . import h5a, h5d, h5ds, h5f, h5fd, h5g, h5p, h5pl, h5py_warnings, h5r, h5s, h5t, h5z, utils, version
 from ._hl import filters
 from ._hl.attrs import AttributeManager
 from ._hl.base import Empty, HLObject, is_hdf5
@@ -33,7 +30,6 @@ from .h5t import (
     string_dtype,
     vlen_dtype,
 )
-from .h5z import _register_lzf
 from .version import version as __version__
 
 defs: Final[ModuleType]
@@ -42,6 +38,7 @@ def run_tests(args: str = ...) -> int: ...
 def enable_ipython_completer() -> None: ...
 
 __all__ = [
+    "UNLIMITED",
     "AttributeManager",
     "Dataset",
     "Datatype",
@@ -55,9 +52,9 @@ __all__ = [
     "Reference",
     "RegionReference",
     "SoftLink",
-    "UNLIMITED",
     "VirtualLayout",
     "VirtualSource",
+    "__version__",
     "atexit",
     "check_dtype",
     "check_enum_dtype",

--- a/h5py-stubs/__init__.pyi
+++ b/h5py-stubs/__init__.pyi
@@ -1,7 +1,7 @@
 import atexit
 from warnings import warn as _warn
 
-from . import _errors, h5a, h5d, h5ds, h5f, h5fd, h5g, h5p, h5pl, h5r, h5s, h5t, h5z, version
+from . import _errors, h5a, h5d, h5ds, h5f, h5fd, h5g, h5p, h5pl, h5r, h5s, h5t, h5z, utils, version
 from ._conv import register_converters as _register_converters
 from ._conv import unregister_converters as _unregister_converters
 from ._hl import filters

--- a/h5py-stubs/__init__.pyi
+++ b/h5py-stubs/__init__.pyi
@@ -1,7 +1,9 @@
 import atexit
+from types import ModuleType
+from typing import Final
 from warnings import warn as _warn
 
-from . import _errors, h5a, h5d, h5ds, h5f, h5fd, h5g, h5p, h5pl, h5r, h5s, h5t, h5z, utils, version
+from . import _errors, h5a, h5d, h5ds, h5f, h5fd, h5g, h5p, h5pl, h5py_warnings, h5r, h5s, h5t, h5z, utils, version
 from ._conv import register_converters as _register_converters
 from ._conv import unregister_converters as _unregister_converters
 from ._hl import filters
@@ -33,6 +35,8 @@ from .h5t import (
 )
 from .h5z import _register_lzf
 from .version import version as __version__
+
+defs: Final[ModuleType]
 
 def run_tests(args: str = ...) -> int: ...
 def enable_ipython_completer() -> None: ...

--- a/h5py-stubs/utils.pyi
+++ b/h5py-stubs/utils.pyi
@@ -1,0 +1,8 @@
+from typing import Any, TypeAlias
+
+import numpy as np
+
+_NDArray: TypeAlias = np.ndarray[Any, Any]
+
+def check_numpy_read(arr: _NDArray, space_id: int = ...) -> int: ...
+def check_numpy_write(arr: _NDArray, space_id: int = ...) -> int: ...

--- a/uv.lock
+++ b/uv.lock
@@ -1,5 +1,5 @@
 version = 1
-requires-python = ">=3.12"
+requires-python = ">=3.11"
 
 [[package]]
 name = "h5py"
@@ -10,6 +10,11 @@ dependencies = [
 ]
 sdist = { url = "https://files.pythonhosted.org/packages/cc/0c/5c2b0a88158682aeafb10c1c2b735df5bc31f165bfe192f2ee9f2a23b5f1/h5py-3.12.1.tar.gz", hash = "sha256:326d70b53d31baa61f00b8aa5f95c2fcb9621a3ee8365d770c551a13dbbcbfdf", size = 411457 }
 wheels = [
+    { url = "https://files.pythonhosted.org/packages/33/61/c463dc5fc02fbe019566d067a9d18746cd3c664f29c9b8b3c3f9ed025365/h5py-3.12.1-cp311-cp311-macosx_10_9_x86_64.whl", hash = "sha256:ccd9006d92232727d23f784795191bfd02294a4f2ba68708825cb1da39511a93", size = 3410828 },
+    { url = "https://files.pythonhosted.org/packages/95/9d/eb91a9076aa998bb2179d6b1788055ea09cdf9d6619cd967f1d3321ed056/h5py-3.12.1-cp311-cp311-macosx_11_0_arm64.whl", hash = "sha256:ad8a76557880aed5234cfe7279805f4ab5ce16b17954606cca90d578d3e713ef", size = 2872586 },
+    { url = "https://files.pythonhosted.org/packages/b0/62/e2b1f9723ff713e3bd3c16dfeceec7017eadc21ef063d8b7080c0fcdc58a/h5py-3.12.1-cp311-cp311-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:1473348139b885393125126258ae2d70753ef7e9cec8e7848434f385ae72069e", size = 5273038 },
+    { url = "https://files.pythonhosted.org/packages/e1/89/118c3255d6ff2db33b062ec996a762d99ae50c21f54a8a6047ae8eda1b9f/h5py-3.12.1-cp311-cp311-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:018a4597f35092ae3fb28ee851fdc756d2b88c96336b8480e124ce1ac6fb9166", size = 5452688 },
+    { url = "https://files.pythonhosted.org/packages/1d/4d/cbd3014eb78d1e449b29beba1f3293a841aa8086c6f7968c383c2c7ff076/h5py-3.12.1-cp311-cp311-win_amd64.whl", hash = "sha256:3fdf95092d60e8130ba6ae0ef7a9bd4ade8edbe3569c13ebbaf39baefffc5ba4", size = 3006095 },
     { url = "https://files.pythonhosted.org/packages/d4/e1/ea9bfe18a3075cdc873f0588ff26ce394726047653557876d7101bf0c74e/h5py-3.12.1-cp312-cp312-macosx_10_13_x86_64.whl", hash = "sha256:06a903a4e4e9e3ebbc8b548959c3c2552ca2d70dac14fcfa650d9261c66939ed", size = 3372538 },
     { url = "https://files.pythonhosted.org/packages/0d/74/1009b663387c025e8fa5f3ee3cf3cd0d99b1ad5c72eeb70e75366b1ce878/h5py-3.12.1-cp312-cp312-macosx_11_0_arm64.whl", hash = "sha256:7b3b8f3b48717e46c6a790e3128d39c61ab595ae0a7237f06dfad6a3b51d5351", size = 2868104 },
     { url = "https://files.pythonhosted.org/packages/af/52/c604adc06280c15a29037d4aa79a24fe54d8d0b51085e81ed24b2fa995f7/h5py-3.12.1-cp312-cp312-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:050a4f2c9126054515169c49cb900949814987f0c7ae74c341b0c9f9b5056834", size = 5194606 },
@@ -43,6 +48,16 @@ version = "2.1.2"
 source = { registry = "https://pypi.org/simple" }
 sdist = { url = "https://files.pythonhosted.org/packages/4b/d1/8a730ea07f4a37d94f9172f4ce1d81064b7a64766b460378be278952de75/numpy-2.1.2.tar.gz", hash = "sha256:13532a088217fa624c99b843eeb54640de23b3414b14aa66d023805eb731066c", size = 18878063 }
 wheels = [
+    { url = "https://files.pythonhosted.org/packages/aa/9c/9a6ec3ae89cd0648d419781284308f2956d2a61d932b5ac9682c956a171b/numpy-2.1.2-cp311-cp311-macosx_10_9_x86_64.whl", hash = "sha256:b42a1a511c81cc78cbc4539675713bbcf9d9c3913386243ceff0e9429ca892fe", size = 21154845 },
+    { url = "https://files.pythonhosted.org/packages/02/69/9f05c4ecc75fabf297b17743996371b4c3dfc4d92e15c5c38d8bb3db8d74/numpy-2.1.2-cp311-cp311-macosx_11_0_arm64.whl", hash = "sha256:faa88bc527d0f097abdc2c663cddf37c05a1c2f113716601555249805cf573f1", size = 13789409 },
+    { url = "https://files.pythonhosted.org/packages/34/4e/f95c99217bf77bbfaaf660d693c10bd0dc03b6032d19316d316088c9e479/numpy-2.1.2-cp311-cp311-macosx_14_0_arm64.whl", hash = "sha256:c82af4b2ddd2ee72d1fc0c6695048d457e00b3582ccde72d8a1c991b808bb20f", size = 5352097 },
+    { url = "https://files.pythonhosted.org/packages/06/13/f5d87a497c16658e9af8920449b0b5692b469586b8231340c672962071c5/numpy-2.1.2-cp311-cp311-macosx_14_0_x86_64.whl", hash = "sha256:13602b3174432a35b16c4cfb5de9a12d229727c3dd47a6ce35111f2ebdf66ff4", size = 6891195 },
+    { url = "https://files.pythonhosted.org/packages/6c/89/691ac07429ac061b344d5e37fa8e94be51a6017734aea15f2d9d7c6d119a/numpy-2.1.2-cp311-cp311-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:1ebec5fd716c5a5b3d8dfcc439be82a8407b7b24b230d0ad28a81b61c2f4659a", size = 13895153 },
+    { url = "https://files.pythonhosted.org/packages/23/69/538317f0d925095537745f12aced33be1570bbdc4acde49b33748669af96/numpy-2.1.2-cp311-cp311-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:e2b49c3c0804e8ecb05d59af8386ec2f74877f7ca8fd9c1e00be2672e4d399b1", size = 16338306 },
+    { url = "https://files.pythonhosted.org/packages/af/03/863fe7062c2106d3c151f7df9353f2ae2237c1dd6900f127a3eb1f24cb1b/numpy-2.1.2-cp311-cp311-musllinux_1_1_x86_64.whl", hash = "sha256:2cbba4b30bf31ddbe97f1c7205ef976909a93a66bb1583e983adbd155ba72ac2", size = 16710893 },
+    { url = "https://files.pythonhosted.org/packages/70/77/0ad9efe25482009873f9660d29a40a8c41a6f0e8b541195e3c95c70684c5/numpy-2.1.2-cp311-cp311-musllinux_1_2_aarch64.whl", hash = "sha256:8e00ea6fc82e8a804433d3e9cedaa1051a1422cb6e443011590c14d2dea59146", size = 14398048 },
+    { url = "https://files.pythonhosted.org/packages/3e/0f/e785fe75544db9f2b0bb1c181e13ceff349ce49753d807fd9672916aa06d/numpy-2.1.2-cp311-cp311-win32.whl", hash = "sha256:5006b13a06e0b38d561fab5ccc37581f23c9511879be7693bd33c7cd15ca227c", size = 6533458 },
+    { url = "https://files.pythonhosted.org/packages/d4/96/450054662295125af861d48d2c4bc081dadcf1974a879b2104613157aa62/numpy-2.1.2-cp311-cp311-win_amd64.whl", hash = "sha256:f1eb068ead09f4994dec71c24b2844f1e4e4e013b9629f812f292f04bd1510d9", size = 12870896 },
     { url = "https://files.pythonhosted.org/packages/a0/7d/554a6838f37f3ada5a55f25173c619d556ae98092a6e01afb6e710501d70/numpy-2.1.2-cp312-cp312-macosx_10_13_x86_64.whl", hash = "sha256:d7bf0a4f9f15b32b5ba53147369e94296f5fffb783db5aacc1be15b4bf72f43b", size = 20848077 },
     { url = "https://files.pythonhosted.org/packages/b0/29/cb48a402ea879e645b16218718f3f7d9588a77d674a9dcf22e4c43487636/numpy-2.1.2-cp312-cp312-macosx_11_0_arm64.whl", hash = "sha256:b1d0fcae4f0949f215d4632be684a539859b295e2d0cb14f78ec231915d644db", size = 13493242 },
     { url = "https://files.pythonhosted.org/packages/56/44/f899b0581766c230da42f751b7b8896d096640b19b312164c267e48d36cb/numpy-2.1.2-cp312-cp312-macosx_14_0_arm64.whl", hash = "sha256:f751ed0a2f250541e19dfca9f1eafa31a392c71c832b6bb9e113b10d050cb0f1", size = 5089219 },


### PR DESCRIPTION
Add in missing type stubs in `__init__.py` and clean up import structure.

This means:
- remove re-exports of private objects
- add in stubs for simple modules like `defs`.